### PR TITLE
fix: Use milestone number instead of name in GitHub API query

### DIFF
--- a/.github/workflows/update-blocked-issues.yml
+++ b/.github/workflows/update-blocked-issues.yml
@@ -146,7 +146,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             // Check if entire phases can be marked as ready
-            const milestones = [
+            const milestoneNames = [
               'Phase 2: Backend Completion',
               'Phase 3: Frontend Foundation',
               'Phase 4: Library Management',
@@ -155,11 +155,31 @@ jobs:
               'Phase 7: Advanced Features'
             ];
 
-            for (const milestone of milestones) {
+            // Fetch all milestones to get their numbers
+            const { data: allMilestones } = await github.rest.issues.listMilestones({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100
+            });
+
+            // Create a map of milestone names to numbers
+            const milestoneMap = new Map(
+              allMilestones.map(m => [m.title, m.number])
+            );
+
+            for (const milestoneName of milestoneNames) {
+              const milestoneNumber = milestoneMap.get(milestoneName);
+
+              if (!milestoneNumber) {
+                console.log(`⚠️  ${milestoneName}: Milestone not found`);
+                continue;
+              }
+
               const { data: issues } = await github.rest.issues.listForRepo({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                milestone: milestone,
+                milestone: milestoneNumber.toString(),
                 state: 'open',
                 per_page: 100
               });
@@ -169,8 +189,8 @@ jobs:
               ).length;
 
               if (blockedCount === 0 && issues.length > 0) {
-                console.log(`📋 ${milestone}: All ${issues.length} issues are unblocked and ready!`);
+                console.log(`📋 ${milestoneName}: All ${issues.length} issues are unblocked and ready!`);
               } else if (blockedCount > 0) {
-                console.log(`⏳ ${milestone}: ${blockedCount}/${issues.length} issues still blocked`);
+                console.log(`⏳ ${milestoneName}: ${blockedCount}/${issues.length} issues still blocked`);
               }
             }


### PR DESCRIPTION
## Summary

Fixes the `check-ready-phase-transitions` workflow job that was failing after PR merges with:
```
Validation Failed: {"value":"Phase 2: Backend Completion","resource":"Issue","field":"milestone","code":"invalid"}
```

## Root Cause

The GitHub API's `issues.listForRepo` endpoint requires the `milestone` parameter to be a **number** (e.g., `2`), not a **string** (e.g., `"Phase 2: Backend Completion"`).

## Changes

Updated `.github/workflows/update-blocked-issues.yml` to:
1. ✅ Fetch all milestones first using `listMilestones` API
2. ✅ Create a map of milestone names → numbers
3. ✅ Use milestone numbers in the `listForRepo` query

## Test Plan

- [x] Workflow syntax is valid
- [ ] Will be tested on next PR merge (when workflow triggers)

## Impact

- **Before:** Workflow failed on every PR merge
- **After:** Workflow correctly reports phase transition status

🤖 Generated with [Claude Code](https://claude.com/claude-code)