### PR TITLE
[Issue #41] Fix word count HTML stripping tests

### DIFF
--- a/src/Alexandria.Domain/Entities/Chapter.cs
+++ b/src/Alexandria.Domain/Entities/Chapter.cs
@@ -57,11 +57,13 @@ public sealed class Chapter
     /// </summary>
     public int GetWordCount()
     {
-        // Strip HTML tags
-        var textOnly = Regex.Replace(Content, @"<[^>]+>", " ");
-        // Strip script and style content
+        var textOnly = Content;
+        // Strip head, script, and style content first (before removing tags)
+        textOnly = Regex.Replace(textOnly, @"<head[^>]*>[\s\S]*?</head>", " ", RegexOptions.IgnoreCase);
         textOnly = Regex.Replace(textOnly, @"<script[^>]*>[\s\S]*?</script>", " ", RegexOptions.IgnoreCase);
         textOnly = Regex.Replace(textOnly, @"<style[^>]*>[\s\S]*?</style>", " ", RegexOptions.IgnoreCase);
+        // Then strip remaining HTML tags
+        textOnly = Regex.Replace(textOnly, @"<[^>]+>", " ");
         // Decode HTML entities
         textOnly = System.Net.WebUtility.HtmlDecode(textOnly);
         // Split by whitespace and count non-empty strings

--- a/tests/Alexandria.Domain.Tests/Entities/ChapterTests.cs
+++ b/tests/Alexandria.Domain.Tests/Entities/ChapterTests.cs
@@ -75,7 +75,7 @@ public class ChapterTests
         var wordCount = chapter.GetWordCount();
 
         // Assert
-        await Assert.That(wordCount).IsEqualTo(14); // "Chapter Title This is the first paragraph This is the second paragraph with more words"
+        await Assert.That(wordCount).IsEqualTo(15); // "Chapter Title This is the first paragraph This is the second paragraph with more words"
     }
 
     [Test]


### PR DESCRIPTION
## Summary
Fixes test failures in `ChapterTests.cs` related to word counting with HTML content.

## Changes
1. **Chapter.cs**: Modified `GetWordCount()` method to strip `<head>`, `<script>`, and `<style>` content BEFORE removing HTML tags (previously stripped tags first, making script/style content visible for counting)
2. **ChapterTests.cs**: Corrected test expectation from 14 to 15 words (test had miscounted the expected words)

## Tests
- ✅ `Should_Calculate_Word_Count_With_HTML_Tags` - now passes with correct count of 15
- ✅ `Should_Strip_HTML_From_Content_For_WordCount` - now passes, properly strips script/style

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)