### PR TITLE
fix: Correct metadata dictionary formatting and add multi-author citation support

### DIFF
--- a/src/Alexandria.Domain/Entities/Book.cs
+++ b/src/Alexandria.Domain/Entities/Book.cs
@@ -364,13 +364,22 @@ public sealed class Book
         var primaryAuthor = GetPrimaryAuthor();
         var year = GetPublicationYear()?.ToString() ?? "n.d.";
         var title = Title.Value;
+        var authorCount = _authors.Count;
 
         return style switch
         {
-            CitationStyle.APA => $"{primaryAuthor.GetLastName()}, {primaryAuthor.GetFirstInitial()}. ({year}). {title}. {Metadata.Publisher ?? "Unknown Publisher"}.",
-            CitationStyle.MLA => $"{primaryAuthor.GetLastName()}, {primaryAuthor.GetFirstName()}. {title}. {Metadata.Publisher ?? "Unknown Publisher"}, {year}.",
-            CitationStyle.Chicago => $"{primaryAuthor.GetLastName()}, {primaryAuthor.GetFirstName()}. {title}. {Metadata.Publisher ?? "Unknown Publisher"}, {year}.",
-            _ => $"{primaryAuthor.Name}. {title}. {year}."
+            CitationStyle.APA => authorCount >= 3
+                ? $"{primaryAuthor.GetLastName()}, {primaryAuthor.GetFirstInitial()}., et al. ({year}). {title}. {Metadata.Publisher ?? "Unknown Publisher"}."
+                : $"{primaryAuthor.GetLastName()}, {primaryAuthor.GetFirstInitial()}. ({year}). {title}. {Metadata.Publisher ?? "Unknown Publisher"}.",
+            CitationStyle.MLA => authorCount >= 3
+                ? $"{primaryAuthor.GetLastName()}, {primaryAuthor.GetFirstName()}, et al. {title}. {Metadata.Publisher ?? "Unknown Publisher"}, {year}."
+                : $"{primaryAuthor.GetLastName()}, {primaryAuthor.GetFirstName()}. {title}. {Metadata.Publisher ?? "Unknown Publisher"}, {year}.",
+            CitationStyle.Chicago => authorCount >= 3
+                ? $"{primaryAuthor.GetLastName()}, {primaryAuthor.GetFirstName()}, et al. {title}. {Metadata.Publisher ?? "Unknown Publisher"}, {year}."
+                : $"{primaryAuthor.GetLastName()}, {primaryAuthor.GetFirstName()}. {title}. {Metadata.Publisher ?? "Unknown Publisher"}, {year}.",
+            _ => authorCount >= 3
+                ? $"{primaryAuthor.Name}, et al. {title}. {year}."
+                : $"{primaryAuthor.Name}. {title}. {year}."
         };
     }
 
@@ -390,13 +399,13 @@ public sealed class Book
             dict["AlternateTitles"] = string.Join("; ", AlternateTitles.Select(t => t.Value));
 
         if (_identifiers.Count > 0)
-            dict["Identifiers"] = string.Join("; ", _identifiers.Select(i => $"{i.Scheme}: {i.Value}"));
+            dict["Identifiers"] = string.Join("; ", _identifiers.Select(i => $"{i.Scheme?.ToLower()}: {i.Value}"));
 
         if (!string.IsNullOrEmpty(Metadata.Publisher))
             dict["Publisher"] = Metadata.Publisher;
 
         if (Metadata.PublicationDate.HasValue)
-            dict["PublicationDate"] = Metadata.PublicationDate.Value.ToString("yyyy-MM-dd");
+            dict["PublicationDate"] = Metadata.PublicationDate.Value.ToString("MM/dd/yyyy");
 
         if (!string.IsNullOrEmpty(Metadata.Description))
             dict["Description"] = Metadata.Description;


### PR DESCRIPTION
## Summary
- Fixed `GetMetadataDictionary()` to use lowercase identifier scheme (e.g., "isbn:" instead of "ISBN:")
- Fixed date format from "yyyy-MM-dd" to "MM/dd/yyyy"
- Added "et al." support for 3+ authors in all citation styles (APA, MLA, Chicago, Simple)

## Changes
- Modified `GetMetadataDictionary()` to use `i.Scheme?.ToLower()`
- Updated date format to `Metadata.PublicationDate.Value.ToString("MM/dd/yyyy")`
- Added conditional logic in `GetCitation()` to include "et al." when author count >= 3

## Test Results
- Both failing tests now pass:
  - `GetMetadataDictionary_ShouldIncludeAllBasicMetadata`
  - `GetCitation_WithMultipleAuthors_ShouldFormatCorrectly`
- Overall test progress: 324/336 passing (up from 322)

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)