### PR TITLE
fix: Correct GetTags_Should_Return_All_Tags test expectation

### DIFF
--- a/tests/Alexandria.Domain.Tests/Entities/BookPhase4MetadataTests.cs
+++ b/tests/Alexandria.Domain.Tests/Entities/BookPhase4MetadataTests.cs
@@ -147,10 +147,9 @@ public class BookPhase4MetadataTests
         var tags = book.GetTags();
 
         // Assert
-        await Assert.That(tags).HasCount().EqualTo(3); // fiction, adventure, plus Fiction from subject
+        await Assert.That(tags).HasCount().EqualTo(2); // fiction and adventure (Fiction subject is duplicate)
         await Assert.That(tags).Contains("fiction");
         await Assert.That(tags).Contains("adventure");
-        await Assert.That(tags).Contains("Fiction");
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- Fixed test expectation for `GetTags_Should_Return_All_Tags` from 3 tags to 2 tags
- The test was incorrectly expecting the subject "Fiction" to be added when "fiction" already exists in the tags

## Problem
The test expected 3 tags (`["fiction", "adventure", "Fiction"]`) but only 2 were returned (`["fiction", "adventure"]`).

## Root Cause
The test expectation was incorrect. The `GetTags()` implementation correctly uses case-insensitive duplicate detection, preventing "Fiction" from being added when "fiction" already exists in the tags array.

## Solution
Updated the test to expect 2 tags instead of 3, which is consistent with:
- The actual behavior of `GetTags()` (case-insensitive duplicate detection)
- The `GetTags_Should_Not_Duplicate_Subject_If_Already_In_Tags` test which explicitly verifies this behavior

## Changes
- Changed expected count from 3 to 2 in `GetTags_Should_Return_All_Tags`
- Removed assertion checking for "Fiction" tag
- Updated comment to clarify that "Fiction" subject is a duplicate of "fiction" tag

## Test Results
- Test now passes (323/336 Domain tests passing, up from 322)

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)